### PR TITLE
fix: removing unneeded pipeline from push master and preparing publishin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@
 
 name: build
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,6 @@
 
 name: lint
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,8 +2,6 @@
 
 name: test-e2e
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master, develop]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@
 
 name: test
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master, develop]
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@maxmilhas/nodejs-trie",
   "description": "A simple trie implementation for faster string lookup",
   "version": "0.0.0",
-  "private": true,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@maxmilhas/nodejs-trie",
   "description": "A simple trie implementation for faster string lookup",
   "version": "1.0.0",
-  "private": true,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"
   },


### PR DESCRIPTION
* Removing some actions from push master, as only semantic-release, which already runs the tests, is needed;
* Removing private: true from package.json, so the first version of the package can be published