### PR TITLE
feat: implementing trie to regexp conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ MatchType.COMPLETE // Complete match
 
 That's it! Simple enough, isn't it?
 
+You can also compile regular expressions from a Trie! There are three flavors for that:
+
+* Partial match regular expression:
+You can generate a regular expression that test returns true when there is a partial match with the Trie. This regular expression will have a performance slightly higher than the arrTrie
+
+```ts
+const regex = trieToRegExPartial(trie);
+```
+
+* Perfect match regular expression:
+You can generate a regular expression that test returns true when there is a perfect match with the Trie. This regular expression will have a performance significantly higher than the arrTrie
+
+```ts
+const regex = trieToRegExPerfect(trie);
+```
+
+* Full Trie match regular expression:
+You can generate a TrieRegexp, which will have a new method, **match**, that returns **MatchType.PERFECT** for a perfect match, **MatchType.PARTIAL** for a partial match, or **MatchType.NONE** for no match! This TrieRegExp between the trie and arrTrie, but almost as good the arrTrie when no match is found, and slightly higher than the normal Trie, when a match occurs!
+
+```ts
+const regex = trieToRegEx(trie);
+```
 
 ## License
 

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -1,4 +1,4 @@
-import { Letter, Trie, MatchType } from './types';
+import { Letter, Trie, MatchType, TrieRegExp } from './types';
 
 export function createTrie(list: string[]) {
 	const trie: Trie = {};
@@ -28,4 +28,52 @@ export function matchesTrie(word: string, trie: Trie) {
 		}
 	}
 	return current.word ? MatchType.PERFECT : MatchType.PARTIAL;
+}
+
+function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
+	let exp = '';
+	for (const k in trie) {
+		if (k !== 'word') {
+			exp += exp !== '' ? `|${k}` : k;
+			exp += trieToRegExRecursive(trie[k as Letter] as Trie, matchType);
+		}
+	}
+
+	return exp !== ''
+		? `(?:${exp}${
+				matchType === MatchType.PERFECT
+					? ''
+					: matchType === MatchType.PARTIAL
+					? '|$'
+					: '|\n'
+		  })`
+		: '';
+}
+
+export function trieToRegExPartial(trie: Trie) {
+	const exp = `^${trieToRegExRecursive(trie, MatchType.PARTIAL)}`;
+	return new RegExp(exp);
+}
+
+export function trieToRegExPerfect(trie: Trie) {
+	const exp = `^${trieToRegExRecursive(trie, MatchType.PERFECT)}`;
+	return new RegExp(exp);
+}
+
+export function trieToRegEx(trie: Trie): TrieRegExp {
+	const exp = `^${trieToRegExRecursive(trie, MatchType.NONE)}`;
+	const regex = new RegExp(exp) as TrieRegExp;
+
+	regex.match = (text: string) => {
+		const result = regex.exec(`${text}\n`);
+		if (!result) {
+			return MatchType.NONE;
+		}
+		const match = result[0];
+		return match[match.length - 1] === '\n'
+			? MatchType.PARTIAL
+			: MatchType.PERFECT;
+	};
+
+	return regex;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,6 @@ export enum MatchType {
 	PARTIAL = 1,
 	PERFECT = 2,
 }
+export type TrieRegExp = RegExp & {
+	match(text: string): MatchType;
+};

--- a/test/e2e/benchmark.spec.ts
+++ b/test/e2e/benchmark.spec.ts
@@ -4,6 +4,9 @@ import {
 	createTrie,
 	matchesArrTrie,
 	matchesTrie,
+	trieToRegEx,
+	trieToRegExPartial,
+	trieToRegExPerfect,
 } from '../../src';
 
 const suite = new Benchmark.Suite();
@@ -63,6 +66,9 @@ const wordList = [
 it('benchmark results', () => {
 	const trie = createTrie(wordList);
 	const arrTrie = createArrTrie(wordList);
+	const regExTrie = trieToRegEx(trie);
+	const regExTriePartial = trieToRegExPartial(trie);
+	const regExTriePerfect = trieToRegExPerfect(trie);
 	const last = wordList[wordList.length - 1];
 	const notFound = 'creed';
 	let log = '';
@@ -81,6 +87,15 @@ it('benchmark results', () => {
 		.add('arrTrie search (not found)', () => {
 			matchesArrTrie(notFound, arrTrie);
 		})
+		.add('regExTrie search (not found)', () => {
+			regExTrie.match(notFound);
+		})
+		.add('regExTriePartial search (not found)', () => {
+			regExTriePartial.test(notFound);
+		})
+		.add('regExTriePerfect search (not found)', () => {
+			regExTriePerfect.test(notFound);
+		})
 		.add('array search (found)', () => {
 			wordList.find((x) => x.startsWith(last));
 		})
@@ -93,6 +108,15 @@ it('benchmark results', () => {
 		})
 		.add('arrTrie search (found)', () => {
 			matchesArrTrie(last, arrTrie);
+		})
+		.add('regExTrie search (found)', () => {
+			regExTrie.match(last);
+		})
+		.add('regExTriePartial search (found)', () => {
+			regExTriePartial.test(last);
+		})
+		.add('regExTriePerfect search (found)', () => {
+			regExTriePerfect.test(last);
 		})
 		.on('cycle', function (event: any) {
 			log += `${event.target}\n`;

--- a/test/unit/trie-regex-partial.spec.ts
+++ b/test/unit/trie-regex-partial.spec.ts
@@ -1,0 +1,48 @@
+import { createTrie, trieToRegExPartial } from '../../src';
+
+describe('trie', () => {
+	it('should return false when there is no matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPartial(trie);
+
+		const result = trieRegEx.test('toast');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return false when there is no matching string from the beginning of the strings', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPartial(trie);
+
+		const result = trieRegEx.test('hirsty');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return false when there is almost a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPartial(trie);
+
+		const result = trieRegEx.test('testa');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return true when there is a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPartial(trie);
+
+		const result = trieRegEx.test('test');
+
+		expect(result).toBe(true);
+	});
+
+	it('should return true when there is a perfect matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPartial(trie);
+
+		const result = trieRegEx.test('taste');
+
+		expect(result).toBe(true);
+	});
+});

--- a/test/unit/trie-regex-perfect.spec.ts
+++ b/test/unit/trie-regex-perfect.spec.ts
@@ -1,0 +1,48 @@
+import { createTrie, trieToRegExPerfect } from '../../src';
+
+describe('trie', () => {
+	it('should return false when there is no matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPerfect(trie);
+
+		const result = trieRegEx.test('toast');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return false when there is no matching string from the beginning of the strings', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPerfect(trie);
+
+		const result = trieRegEx.test('hirsty');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return false when there is almost a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPerfect(trie);
+
+		const result = trieRegEx.test('testa');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return false when there is a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPerfect(trie);
+
+		const result = trieRegEx.test('test');
+
+		expect(result).toBe(false);
+	});
+
+	it('should return true when there is a perfect matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegExPerfect(trie);
+
+		const result = trieRegEx.test('taste');
+
+		expect(result).toBe(true);
+	});
+});

--- a/test/unit/trie-regex.spec.ts
+++ b/test/unit/trie-regex.spec.ts
@@ -1,0 +1,49 @@
+import { MatchType } from './../../src/types';
+import { createTrie, trieToRegEx } from '../../src';
+
+describe('trie', () => {
+	it('should return MatchType.NONE when there is no matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegEx(trie);
+
+		const result = trieRegEx.match('toast');
+
+		expect(result).toBe(MatchType.NONE);
+	});
+
+	it('should return MatchType.NONE when there is no matching string from the beginning of the strings', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegEx(trie);
+
+		const result = trieRegEx.match('hirsty');
+
+		expect(result).toBe(MatchType.NONE);
+	});
+
+	it('should return MatchType.NONE when there is almost a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegEx(trie);
+
+		const result = trieRegEx.match('testa');
+
+		expect(result).toBe(MatchType.NONE);
+	});
+
+	it('should return MatchType.PARTIAL when there is a partial matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegEx(trie);
+
+		const result = trieRegEx.match('test');
+
+		expect(result).toBe(MatchType.PARTIAL);
+	});
+
+	it('should return MatchType.PERFECT when there is a perfect matching string', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+		const trieRegEx = trieToRegEx(trie);
+
+		const result = trieRegEx.match('taste');
+
+		expect(result).toBe(MatchType.PERFECT);
+	});
+});


### PR DESCRIPTION
This feature will allow you to compile a regular expression from a Trie.

There are three flavors for that:

* Partial match regular expression:
You can generate a regular expression that test returns true when there is a partial match with the Trie. This regular expression will have a performance slightly higher than the arrTrie

```ts
const regex = trieToRegExPartial(trie);
```

* Perfect match regular expression:
You can generate a regular expression that test returns true when there is a perfect match with the Trie. This regular expression will have a performance significantly higher than the arrTrie

```ts
const regex = trieToRegExPerfect(trie);
```

* Full Trie match regular expression:
You can generate a TrieRegexp, which will have a new method, **match**, that returns **MatchType.PERFECT** for a perfect match, **MatchType.PARTIAL** for a partial match, or **MatchType.NONE** for no match! This TrieRegExp between the trie and arrTrie, but almost as good the arrTrie when no match is found, and slightly higher than the normal Trie, when a match occurs!

```ts
const regex = trieToRegEx(trie);
```

Here it is the local benchmark:
![image](https://user-images.githubusercontent.com/5713887/168070657-61e15774-9cbb-4d47-9497-52502eda256c.png)
