### PR TITLE
feat: implementing support for char synonyms arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ You can also compile regular expressions from a Trie! There are three flavors fo
 * Partial match regular expression:
 You can generate a regular expression that test returns true when there is a partial match with the Trie. This regular expression will have a performance slightly higher than the arrTrie
 
-
 ## RegEx conversion
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ You can also compile regular expressions from a Trie! There are three flavors fo
 * Partial match regular expression:
 You can generate a regular expression that test returns true when there is a partial match with the Trie. This regular expression will have a performance slightly higher than the arrTrie
 
+
+## RegEx conversion
+
 ```ts
 const regex = trieToRegExPartial(trie);
 ```
@@ -70,6 +73,36 @@ You can generate a TrieRegexp, which will have a new method, **match**, that ret
 ```ts
 const regex = trieToRegEx(trie);
 ```
+
+## Char Synonyms
+
+The char synonyms feature allow you to inform an array of list of synonyms to this package, and it's used to create self referencing keys that will allow even unknown strings to match. This is useful to abstract possible user misspellings.
+
+To use that feature, first, you need to process the char synonyms, like that:
+
+```ts
+const processedSynonyms = processCharSynonyms([
+  ['x', 'ch', 'sh'],
+  ['y', 'i'],
+  ['s', 'ss', 'z'],
+]);
+```
+
+Then, you can inform it to **createTrie** (for now, only createTrie supports char synonyms):
+
+```ts
+const trie = createTrie(['sand', 'chore', 'passport'], processedSynonyms);
+```
+
+Now, the following strings will match:
+
+```ts
+matchesTrie('shand', trie) // MatchType.PERFECT
+matchesTrie('core', trie) // MatchType.PERFECT
+matchesTrie('paspor', trie) // MatchType.PARTIAL
+```
+
+Tries created with synonyms, for now, can't be converted to regex.
 
 ## License
 

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -1,39 +1,142 @@
-import { Letter, Trie, MatchType, TrieRegExp } from './types';
+import {
+	Letter,
+	Trie,
+	MatchType,
+	TrieRegExp,
+	ProcessedSynonyms,
+} from './types';
 
-export function createTrie(list: string[]) {
-	const trie: Trie = {};
+const RESERVED_WORDS = new Set(['$word', '$synonymTrie']);
 
-	for (const item of list) {
-		let current = trie;
-		for (const char of item) {
-			let node = current[char as Letter];
+function getLastPerfectMatch(trie: Trie, word: string, startIndex: number) {
+	let current = trie;
+	let lastIndex = startIndex;
+	const { length } = word;
+
+	for (let i = startIndex; i < length; i++) {
+		current = current[word[i] as Letter] as Trie;
+		if (!current) {
+			break;
+		} else if (current.$word) {
+			lastIndex = i + 1;
+		}
+	}
+
+	if (startIndex !== lastIndex) {
+		return word.substring(startIndex, lastIndex);
+	}
+}
+
+export function addWord(trie: Trie, word: string) {
+	let current = trie;
+	const synonymTrie = trie.$synonymTrie;
+
+	for (let i = 0; i < word.length; i++) {
+		let char = word[i];
+		if (synonymTrie) {
+			const perfectMatch = getLastPerfectMatch(synonymTrie[0], word, i);
+			if (perfectMatch) {
+				i += perfectMatch.length - 1;
+				char = perfectMatch;
+			}
+		}
+		let node = current[char as Letter];
+		if (!node) {
 			if (!node) {
 				node = current[char as Letter] = {};
+				if (synonymTrie) {
+					const synonyms = synonymTrie[1].get(char);
+					if (synonyms) {
+						synonyms.forEach((synonym) => {
+							if (synonym !== char) {
+								current[synonym as Letter] = char;
+							}
+						});
+					}
+				}
 			}
-			current = node;
+		} else if (typeof node === 'string') {
+			node = current[node as Letter] as Trie;
 		}
-		current.word = true;
+		current = node as Trie;
+	}
+	current.$word = true;
+}
+
+export function createEmptyTrie(
+	synonymTrie?: [Trie, Map<string, string[]>],
+): Trie {
+	return { $synonymTrie: synonymTrie };
+}
+
+export function createTrie(
+	list: Iterable<string>,
+	synonymTrie?: [Trie, Map<string, string[]>],
+) {
+	const trie: Trie = createEmptyTrie(synonymTrie);
+
+	for (const item of list) {
+		addWord(trie, item);
 	}
 
 	return trie;
 }
 
+export function processCharSynonyms(
+	synonymChars: string[][],
+): ProcessedSynonyms {
+	const set = new Set<string>();
+	const trie: Trie = {};
+	const synonymMap = new Map<string, string[]>();
+
+	for (const synonyms of synonymChars) {
+		for (const synonym of synonyms) {
+			if (RESERVED_WORDS.has(synonym)) {
+				throw new Error(`The word ${synonym} is reserved!`);
+			}
+			if (set.has(synonym)) {
+				throw new Error(`Synonym ${synonym} informed more than once!`);
+			}
+			set.add(synonym);
+			addWord(trie, synonym);
+			synonymMap.set(synonym, synonyms);
+		}
+	}
+
+	return [trie, synonymMap];
+}
+
 export function matchesTrie(word: string, trie: Trie) {
 	let current = trie;
 	const { length } = word;
+	const synonymTrie = trie.$synonymTrie;
+
 	for (let i = 0; i < length; i++) {
-		current = current[word[i] as Letter] as Trie;
-		if (!current) {
+		let char = word[i];
+		if (synonymTrie) {
+			const perfectMatch = getLastPerfectMatch(synonymTrie[0], word, i);
+			if (perfectMatch) {
+				i += perfectMatch.length - 1;
+				char = perfectMatch;
+			}
+		}
+		const nextNode = current[char as Letter];
+		if (nextNode) {
+			current =
+				typeof nextNode === 'string'
+					? (current[nextNode as Letter] as Trie)
+					: nextNode;
+		} else {
 			return MatchType.NONE;
 		}
 	}
-	return current.word ? MatchType.PERFECT : MatchType.PARTIAL;
+	return current.$word ? MatchType.PERFECT : MatchType.PARTIAL;
 }
 
 function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
 	let exp = '';
 	for (const k in trie) {
-		if (k !== 'word') {
+		if (!RESERVED_WORDS.has(k)) {
 			exp += exp !== '' ? `|${k}` : k;
 			exp += trieToRegExRecursive(trie[k as Letter] as Trie, matchType);
 		}
@@ -50,17 +153,29 @@ function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
 		: '';
 }
 
+function validateRegEx(trie: Trie) {
+	if (trie.$synonymTrie) {
+		throw new TypeError('TrieRegEx does not support tries with synonyms yet');
+	}
+}
+
 export function trieToRegExPartial(trie: Trie) {
+	validateRegEx(trie);
+
 	const exp = `^${trieToRegExRecursive(trie, MatchType.PARTIAL)}`;
 	return new RegExp(exp);
 }
 
 export function trieToRegExPerfect(trie: Trie) {
+	validateRegEx(trie);
+
 	const exp = `^${trieToRegExRecursive(trie, MatchType.PERFECT)}`;
 	return new RegExp(exp);
 }
 
 export function trieToRegEx(trie: Trie): TrieRegExp {
+	validateRegEx(trie);
+
 	const exp = `^${trieToRegExRecursive(trie, MatchType.NONE)}`;
 	const regex = new RegExp(exp) as TrieRegExp;
 

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -35,6 +35,23 @@ function getLastPerfectMatch(
 	}
 }
 
+function selfReferenceSynonyms(
+	synonymTrie: ProcessedSynonyms | undefined,
+	char: string,
+	current: Trie,
+) {
+	if (synonymTrie) {
+		const synonyms = synonymTrie[1].get(char);
+		if (synonyms) {
+			synonyms.forEach((synonym) => {
+				if (synonym !== char) {
+					current[synonym as Letter] = char;
+				}
+			});
+		}
+	}
+}
+
 export function addWord(trie: Trie, word: string) {
 	let current = trie;
 	const context = { i: 0, char: '' };
@@ -46,23 +63,12 @@ export function addWord(trie: Trie, word: string) {
 		const { char } = context;
 		let node = current[char as Letter];
 		if (!node) {
-			if (!node) {
-				node = current[char as Letter] = {};
-				if (synonymTrie) {
-					const synonyms = synonymTrie[1].get(char);
-					if (synonyms) {
-						synonyms.forEach((synonym) => {
-							if (synonym !== char) {
-								current[synonym as Letter] = char;
-							}
-						});
-					}
-				}
-			}
+			node = current[char as Letter] = {};
+			selfReferenceSynonyms(synonymTrie, char, current);
 		} else if (typeof node === 'string') {
 			node = current[node as Letter] as Trie;
 		}
-		current = node as Trie;
+		current = node;
 	}
 	current.$word = true;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,10 +25,14 @@ export type Letter =
 	| 'x'
 	| 'y'
 	| 'z';
+
+export type ProcessedSynonyms = [Trie, Map<string, string[]>];
+
 export type Trie = {
-	[k in Letter]?: Trie;
+	[k in Letter]?: Trie | string;
 } & {
-	word?: boolean;
+	$word?: boolean;
+	$synonymTrie?: ProcessedSynonyms;
 };
 export interface ArrayTrie extends Array<ArrayTrie | undefined> {
 	word?: boolean;

--- a/test/unit/trie-regex-partial.spec.ts
+++ b/test/unit/trie-regex-partial.spec.ts
@@ -1,6 +1,22 @@
-import { createTrie, trieToRegExPartial } from '../../src';
+import { createTrie, processCharSynonyms, trieToRegExPartial } from '../../src';
 
 describe('trie', () => {
+	it('should thrown an error when trying to convert a trie with synonyms', () => {
+		const trie = createTrie(
+			['testing', 'taste', 'thirsty'],
+			processCharSynonyms([['t', 'th']]),
+		);
+		let error: any;
+
+		try {
+			trieToRegExPartial(trie);
+		} catch (err) {
+			error = err;
+		}
+
+		expect(error).toBeInstanceOf(TypeError);
+	});
+
 	it('should return false when there is no matching string', () => {
 		const trie = createTrie(['testing', 'taste', 'thirsty']);
 		const trieRegEx = trieToRegExPartial(trie);

--- a/test/unit/trie-regex-perfect.spec.ts
+++ b/test/unit/trie-regex-perfect.spec.ts
@@ -1,6 +1,22 @@
-import { createTrie, trieToRegExPerfect } from '../../src';
+import { createTrie, processCharSynonyms, trieToRegExPerfect } from '../../src';
 
 describe('trie', () => {
+	it('should thrown an error when trying to convert a trie with synonyms', () => {
+		const trie = createTrie(
+			['testing', 'taste', 'thirsty'],
+			processCharSynonyms([['t', 'th']]),
+		);
+		let error: any;
+
+		try {
+			trieToRegExPerfect(trie);
+		} catch (err) {
+			error = err;
+		}
+
+		expect(error).toBeInstanceOf(TypeError);
+	});
+
 	it('should return false when there is no matching string', () => {
 		const trie = createTrie(['testing', 'taste', 'thirsty']);
 		const trieRegEx = trieToRegExPerfect(trie);

--- a/test/unit/trie-regex.spec.ts
+++ b/test/unit/trie-regex.spec.ts
@@ -1,7 +1,23 @@
 import { MatchType } from './../../src/types';
-import { createTrie, trieToRegEx } from '../../src';
+import { createTrie, processCharSynonyms, trieToRegEx } from '../../src';
 
 describe('trie', () => {
+	it('should thrown an error when trying to convert a trie with synonyms', () => {
+		const trie = createTrie(
+			['testing', 'taste', 'thirsty'],
+			processCharSynonyms([['t', 'th']]),
+		);
+		let error: any;
+
+		try {
+			trieToRegEx(trie);
+		} catch (err) {
+			error = err;
+		}
+
+		expect(error).toBeInstanceOf(TypeError);
+	});
+
 	it('should return MatchType.NONE when there is no matching string', () => {
 		const trie = createTrie(['testing', 'taste', 'thirsty']);
 		const trieRegEx = trieToRegEx(trie);

--- a/test/unit/trie.spec.ts
+++ b/test/unit/trie.spec.ts
@@ -1,36 +1,186 @@
 import { MatchType } from './../../src/types';
-import { createTrie, matchesTrie } from '../../src';
+import { createTrie, matchesTrie, processCharSynonyms } from '../../src';
 
 describe('trie', () => {
-	it('should return MatchType.NONE when there is no matching string', () => {
-		const trie = createTrie(['testing', 'taste', 'thirsty']);
+	describe(matchesTrie.name, () => {
+		it('should return MatchType.NONE when there is no matching string', () => {
+			const trie = createTrie(['testing', 'taste', 'thirsty']);
 
-		const result = matchesTrie('toast', trie);
+			const result = matchesTrie('toast', trie);
 
-		expect(result).toBe(MatchType.NONE);
+			expect(result).toBe(MatchType.NONE);
+		});
+
+		it('should return MatchType.NONE when there is no matching string from the beginning of the strings', () => {
+			const trie = createTrie(['testing', 'taste', 'thirsty']);
+
+			const result = matchesTrie('hirsty', trie);
+
+			expect(result).toBe(MatchType.NONE);
+		});
+
+		it('should return MatchType.PARTIAL when there is a partial matching string', () => {
+			const trie = createTrie(['testing', 'taste', 'thirsty']);
+
+			const result = matchesTrie('test', trie);
+
+			expect(result).toBe(MatchType.PARTIAL);
+		});
+
+		it('should return MatchType.PERFECT when there is a perfect matching string', () => {
+			const trie = createTrie(['testing', 'taste', 'thirsty']);
+
+			const result = matchesTrie('taste', trie);
+
+			expect(result).toBe(MatchType.PERFECT);
+		});
+
+		it('should match an unknown word that have char synonym match', () => {
+			const trie = createTrie(
+				['testing', 'taste', 'thirsty'],
+				processCharSynonyms([['th', 't']]),
+			);
+
+			const result1 = matchesTrie('thaste', trie);
+			const result2 = matchesTrie('tasthe', trie);
+			const result3 = matchesTrie('thasthe', trie);
+
+			expect(result1).toBe(MatchType.PERFECT);
+			expect(result2).toBe(MatchType.PERFECT);
+			expect(result3).toBe(MatchType.PERFECT);
+		});
+
+		it('should partial match when an unknown word that have char synonym match partially', () => {
+			const trie = createTrie(
+				['testing', 'taste', 'thirsty'],
+				processCharSynonyms([['th', 't']]),
+			);
+
+			const result1 = matchesTrie('thast', trie);
+			const result2 = matchesTrie('tasth', trie);
+			const result3 = matchesTrie('thasth', trie);
+
+			expect(result1).toBe(MatchType.PARTIAL);
+			expect(result2).toBe(MatchType.PARTIAL);
+			expect(result3).toBe(MatchType.PARTIAL);
+		});
+
+		it('should none when an unknown word that have char synonym match partially', () => {
+			const trie = createTrie(
+				['testing', 'taste', 'thirsty'],
+				processCharSynonyms([['th', 't']]),
+			);
+
+			const result1 = matchesTrie('thasti', trie);
+			const result2 = matchesTrie('tasthi', trie);
+			const result3 = matchesTrie('thasthi', trie);
+
+			expect(result1).toBe(MatchType.NONE);
+			expect(result2).toBe(MatchType.NONE);
+			expect(result3).toBe(MatchType.NONE);
+		});
 	});
 
-	it('should return MatchType.NONE when there is no matching string from the beginning of the strings', () => {
-		const trie = createTrie(['testing', 'taste', 'thirsty']);
+	describe(processCharSynonyms.name, () => {
+		it('should return a trie and a map pointing to the original synonyms array for each synonym', () => {
+			const result = processCharSynonyms([
+				['t', 'th', 'xx'],
+				['jasper', 'x', 'j'],
+			]);
 
-		const result = matchesTrie('hirsty', trie);
+			expect(result[0]).toEqual({
+				t: {
+					$word: true,
+					h: {
+						$word: true,
+					},
+				},
+				x: {
+					$word: true,
+					x: {
+						$word: true,
+					},
+				},
+				j: {
+					$word: true,
+					a: {
+						s: {
+							p: {
+								e: {
+									r: {
+										$word: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			});
+			expect(result[1]).toEqual(
+				new Map([
+					['t', ['t', 'th', 'xx']],
+					['th', ['t', 'th', 'xx']],
+					['xx', ['t', 'th', 'xx']],
+					['jasper', ['jasper', 'x', 'j']],
+					['x', ['jasper', 'x', 'j']],
+					['j', ['jasper', 'x', 'j']],
+				]),
+			);
+		});
 
-		expect(result).toBe(MatchType.NONE);
-	});
+		it('should throw an error when repeated synonyms are informed', () => {
+			let error1: any;
+			let error2: any;
 
-	it('should return MatchType.PARTIAL when there is a partial matching string', () => {
-		const trie = createTrie(['testing', 'taste', 'thirsty']);
+			try {
+				processCharSynonyms([
+					['t', 'th', 't'],
+					['jasper', 'x'],
+				]);
+			} catch (err) {
+				error1 = err;
+			}
+			try {
+				processCharSynonyms([
+					['t', 'th'],
+					['jasper', 'x', 't'],
+				]);
+			} catch (err) {
+				error2 = err;
+			}
 
-		const result = matchesTrie('test', trie);
+			expect(error1).toBeInstanceOf(Error);
+			expect(error2).toBeInstanceOf(Error);
+		});
 
-		expect(result).toBe(MatchType.PARTIAL);
-	});
+		it('should throw an error when a reserved $word is informed as synonym', () => {
+			let error: any;
 
-	it('should return MatchType.PERFECT when there is a perfect matching string', () => {
-		const trie = createTrie(['testing', 'taste', 'thirsty']);
+			try {
+				processCharSynonyms([
+					['t', 'th'],
+					['$word', 'x'],
+				]);
+			} catch (err) {
+				error = err;
+			}
 
-		const result = matchesTrie('taste', trie);
+			expect(error).toBeInstanceOf(Error);
+		});
 
-		expect(result).toBe(MatchType.PERFECT);
+		it('should throw an error when a reserved $synonymTrie is informed as synonym', () => {
+			let error: any;
+
+			try {
+				processCharSynonyms([
+					['t', 'th'],
+					['$synonymTrie', 'x'],
+				]);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error).toBeInstanceOf(Error);
+		});
 	});
 });


### PR DESCRIPTION
The char synonyms feature allow you to inform an array of list of synonyms to this package, and it's used to create self referencing keys that will allow even unknown strings to match. This is useful to abstract possible user misspellings.

To use that feature, first, you need to process the char synonyms, like that:

```ts
const processedSynonyms = processCharSynonyms([
  ['x', 'ch', 'sh'],
  ['y', 'i'],
  ['s', 'ss', 'z'],
]);
```

Then, you can inform it to **createTrie** (for now, only createTrie supports char synonyms):

```ts
const trie = createTrie(['sand', 'chore', 'passport'], processedSynonyms);
```

Now, the following strings will match:

```ts
matchesTrie('shand', trie) // MatchType.PERFECT
matchesTrie('core', trie) // MatchType.PERFECT
matchesTrie('paspor', trie) // MatchType.PARTIAL
```

Tries created with synonyms, for now, can't be converted to regex.