### PR TITLE
fix: fixing Reserved Words list

### DIFF
--- a/src/trie.ts
+++ b/src/trie.ts
@@ -5,9 +5,15 @@ import {
 	TrieRegExp,
 	ProcessedSynonyms,
 	IteratedTrieValue,
+	ReservedWords,
 } from './types';
 
-const RESERVED_WORDS = new Set(['$word', '$synonymTrie', '$value']);
+const RESERVED_WORDS = new Set<string>();
+for (const key in ReservedWords) {
+	if (ReservedWords.hasOwnProperty(key)) {
+		RESERVED_WORDS.add(key);
+	}
+}
 
 function getLastPerfectMatch(
 	processedSynonyms: ProcessedSynonyms | undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,14 +26,20 @@ export type Letter =
 	| 'y'
 	| 'z';
 
+export enum ReservedWords {
+	$word = '$word',
+	$synonymTrie = '$synonymTrie',
+	$values = '$values',
+}
+
 export type ProcessedSynonyms = [Trie, Map<string, string[]>];
 
 export type Trie<TValue = unknown> = {
 	[k in Letter]?: Trie<TValue> | string;
 } & {
-	$word?: string;
-	$synonymTrie?: ProcessedSynonyms;
-	$values?: TValue[];
+	[ReservedWords.$word]?: string;
+	[ReservedWords.$synonymTrie]?: ProcessedSynonyms;
+	[ReservedWords.$values]?: TValue[];
 };
 
 export interface IteratedTrieValue<TValue> {

--- a/test/e2e/benchmark.spec.ts
+++ b/test/e2e/benchmark.spec.ts
@@ -62,6 +62,7 @@ const wordList = [
 	'fabricate',
 	'creep',
 ];
+const EXPECTED_IMPROVEMENT_FACTOR = 5;
 
 it('benchmark results', () => {
 	const trie = createTrie(wordList);
@@ -71,7 +72,9 @@ it('benchmark results', () => {
 	const regExTriePerfect = trieToRegExPerfect(trie);
 	const last = wordList[wordList.length - 1];
 	const notFound = 'creed';
+	let trieCount = 0;
 	let log = '';
+	const totals: [number, string][] = [];
 
 	suite
 		.add('array search (not found)', () => {
@@ -81,7 +84,7 @@ it('benchmark results', () => {
 			const regex = new RegExp(`\\b${notFound}`);
 			wordList.find((x) => regex.test(x));
 		})
-		.add('trie search (not found)', () => {
+		.add('Trie search (not found)', () => {
 			matchesTrie(notFound, trie);
 		})
 		.add('arrTrie search (not found)', () => {
@@ -103,7 +106,7 @@ it('benchmark results', () => {
 			const regex = new RegExp(`\\b${last}`);
 			wordList.find((x) => regex.test(x));
 		})
-		.add('trie search (found)', () => {
+		.add('Trie search (found)', () => {
 			matchesTrie(last, trie);
 		})
 		.add('arrTrie search (found)', () => {
@@ -120,9 +123,21 @@ it('benchmark results', () => {
 		})
 		.on('cycle', function (event: any) {
 			log += `${event.target}\n`;
+			totals.push([event.target.hz, event.target.name]);
+			if (event.target.name.includes('Trie')) {
+				trieCount++;
+			}
 		})
 		.on('complete', () => {
 			console.log(log);
+			totals.sort(([a], [b]) => b - a);
+			let i = 0;
+			for (; i < trieCount; i++) {
+				expect(totals[i][1]).toInclude('Trie');
+			}
+			expect(totals[i - 1][0]).toBeGreaterThanOrEqual(
+				totals[i][0] * EXPECTED_IMPROVEMENT_FACTOR,
+			);
 		})
 		.on('error', (err: any) => {
 			console.log(err);

--- a/test/jest-setup.ts
+++ b/test/jest-setup.ts
@@ -1,3 +1,4 @@
+const matchers = require('jest-extended/all');
 import 'jest-extended';
 import 'jest-callslike';
 
@@ -5,6 +6,7 @@ afterEach(() => {
 	jest.restoreAllMocks();
 	jest.clearAllMocks();
 });
+expect.extend(matchers);
 
 declare global {
 	function getNames<T extends object>(c: { prototype: T }): T;


### PR DESCRIPTION
reserved word $values were wrongly defined as $value, which broke iterations

I also updated the benchmark test to make it validate that all Trie searches are indeed faster than the naive ones