### PR TITLE
feat: implementing multiple prefixes iteration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,7 +58,7 @@ module.exports = {
     'default-case': 'error',
     'eol-last': 'error',
     eqeqeq: ['error', 'smart'],
-    'guard-for-in': 'error',
+    'guard-for-in': 'off',
     'id-blacklist': 'error',
     'id-match': 'error',
     'linebreak-style': ['error', 'unix'],

--- a/README.md
+++ b/README.md
@@ -123,15 +123,71 @@ for (const item of iterateTrieValues(trie, 'tes')) {
   console.log(item);
 }
 /*
-Result: will print in some arbitrary order
-{ proximity: 4, word: 'testing', value: 1 },
-{ proximity: 3, word: 'tester', value: 4 },
-{ proximity: 1, word: 'test', value: 5 },
-{ proximity: 4, word: 'testing', value: 5 },
+Result: will print in proximity order
+{ proximity: 1, value: 5 },
+{ proximity: 3, value: 4 },
+{ proximity: 4, value: 1 },
+{ proximity: 4, value: 5 },
 */
 ```
 
-Notice that **IterateTrieValues** will yield even repeated values. If you want uniqueness, it's up to you to treat the data as you need.
+Notice that **IterateTrieValues** will yield even repeated values. If you want uniqueness, you can inform it:
+
+```ts
+const trie = createTrieMap([
+  ['testing', 1],
+  ['taste', 2],
+  ['thirsty', 3],
+  ['tester', 4],
+  ['test', 5],
+  ['taste', 6],
+  ['thirsty', 7],
+  ['testing', 5],
+]);
+
+for (const item of iterateTrieValues(trie, {
+  prefixes: 'tes',
+  uniqueness: true,
+)) {
+  console.log(item);
+}
+/*
+Result: will print in proximity order
+{ proximity: 1, value: 5 },
+{ proximity: 3, value: 4 },
+{ proximity: 4, value: 1 },
+*/
+```
+
+You can also inform multiple prefixes and you'll get an iterable with only the values found for all of them.
+Notice that this feature implies uniqueness, and if you try to use it with uniqueness false, you'll get an error.
+Also, the proximity in the case will be the average proximity for the value with all the prefixes, and you have
+no guarantees that the items will be printed in proximity order.
+
+```ts
+const trie = createTrieMap([
+  ['testing', 1],
+  ['taste', 2],
+  ['thirsty', 3],
+  ['testing', 4],
+  ['test', 2],
+  ['tas', 4],
+  ['thirsty', 7],
+  ['testing', 5],
+]);
+
+for (const item of iterateTrieValues(trie, {
+  prefixes: ['tes', 'tas'],
+)) {
+  console.log(item);
+}
+
+/*
+Result: will print in some arbitrary order
+{ proximity: 1.5, value: 2 },
+{ proximity: 2, value: 4 },
+*/
+```
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from './arr-trie';
 export * from './trie';
 export * from './types';
+export * from './trie-regex';
+export * from './iterate-trie-values';

--- a/src/iterate-trie-values.ts
+++ b/src/iterate-trie-values.ts
@@ -1,0 +1,284 @@
+import { addWord, createEmptyTrie, createTrie } from './trie';
+import { IteratedTrieValue, IteratingOptions, Trie } from './types';
+
+type IdItem<TValue> = IteratedTrieValue<TValue> & {
+	id: unknown;
+	count: number;
+};
+type QueueNode<T> =
+	| {
+			value: T;
+			next?: QueueNode<T>;
+	  }
+	| undefined;
+type Queue<T> = {
+	push(item: T): void;
+	shift(): T | undefined;
+	hasItems(): unknown;
+};
+type ShouldYield = (v: unknown) => {
+	yields: boolean;
+	id: unknown;
+};
+
+const YIELDS_TRUE = { yields: true, id: undefined };
+const ALWAYS_YIELDS = () => YIELDS_TRUE;
+
+function pushToStack<TValue>(
+	current: Trie<TValue>,
+	visited: Set<Trie<TValue>>,
+	stack: Queue<[Trie<TValue>, number]>,
+	proximity: number,
+) {
+	for (const [, value] of current.sub) {
+		if (typeof value !== 'string' && !visited.has(value)) {
+			visited.add(current);
+			stack.push([value, proximity]);
+		}
+	}
+}
+
+const identity = (x: unknown) => x;
+function getPrefixTrie(
+	prefixes: string | Iterable<string> | undefined,
+	dataTrie: Trie,
+): [Trie | undefined, number] {
+	if (prefixes === undefined) {
+		return [undefined, 0];
+	}
+	const trie = createEmptyTrie(dataTrie.$synonymTrie);
+	if (typeof prefixes === 'string') {
+		prefixes = [prefixes];
+	}
+	let count = 0;
+	for (const prefix of prefixes) {
+		addWord(trie, prefix);
+		count++;
+	}
+
+	return [trie, count];
+}
+
+function treatOptions<TValue>(
+	prefixOrPrefix: IteratingOptions<TValue>,
+	trie: Trie<TValue>,
+) {
+	const [prefixes, count] = getPrefixTrie(prefixOrPrefix.prefixes, trie);
+	let uniqueness = prefixOrPrefix.uniqueness;
+	const getId = prefixOrPrefix.getId;
+
+	if (prefixes) {
+		const manyPrefixes = count > 1;
+		if (uniqueness === undefined) {
+			uniqueness = manyPrefixes || !getId;
+		} else if (uniqueness === false && manyPrefixes) {
+			throw new TypeError(
+				'It is not allowed to have uniqueness false and more than one prefix',
+			);
+		}
+	}
+	return { prefixes, uniqueness, getId: getId || identity };
+}
+
+function validateIterationParameters<TValue>(
+	prefixOrPrefix: string | IteratingOptions<TValue> | undefined,
+	trie: Trie<TValue>,
+) {
+	let prefixes: Trie | undefined;
+	if (prefixOrPrefix) {
+		if (typeof prefixOrPrefix === 'object') {
+			return treatOptions(prefixOrPrefix, trie);
+		}
+		prefixes = createTrie([prefixOrPrefix], trie.$synonymTrie);
+	}
+
+	return { prefixes, uniqueness: false, getId: identity };
+}
+
+function getQueue<T>(): Queue<T> {
+	let first: QueueNode<T> | undefined;
+	let last: QueueNode<T> | undefined;
+	return {
+		hasItems() {
+			return first;
+		},
+		shift() {
+			if (first) {
+				const { value } = first;
+				first = first.next;
+				if (!first) {
+					last = first;
+				}
+				return value;
+			}
+		},
+		push(value: T) {
+			const node = { value };
+			if (!last) {
+				first = last = node;
+			} else {
+				last = last.next = node;
+			}
+		},
+	};
+}
+
+function shouldYieldFactory(
+	uniqueness: boolean | undefined,
+	yielded: Set<unknown>,
+	getId: Function,
+) {
+	if (uniqueness) {
+		return (value: unknown) => {
+			const id = getId(value);
+			if (yielded.has(id)) return { yields: false, id };
+			yielded.add(id);
+			return { yields: true, id };
+		};
+	}
+
+	return ALWAYS_YIELDS;
+}
+
+function* yieldValues<TValue>(
+	shouldYield: ShouldYield,
+	values: TValue[],
+	proximity: number,
+) {
+	const { length } = values;
+	for (let i = 0; i < length; i++) {
+		const value = values[i];
+		const { yields, id } = shouldYield(value);
+		if (yields) {
+			yield { proximity, value, id, count: 1 };
+		}
+	}
+}
+
+function* runIteration<TValue>(
+	trie: Trie<TValue>,
+	uniqueness: boolean | undefined,
+	getId: (x: TValue) => unknown,
+): Iterable<IdItem<TValue>> {
+	const visited = new Set([trie]);
+	const yielded = new Set();
+	const queue = getQueue<[Trie<TValue>, number]>();
+	queue.push([trie, 0]);
+	const shouldYield = shouldYieldFactory(uniqueness, yielded, getId);
+
+	while (queue.hasItems()) {
+		const [current, proximity] = queue.shift()!;
+		const word = current.$word;
+		const values = current.$values;
+		if (word && values) {
+			yield* yieldValues(shouldYield, values, proximity);
+		}
+		pushToStack(current, visited, queue, proximity + 1);
+	}
+}
+
+function* combineIterables<TValue>(
+	iterable1: Iterable<IdItem<TValue>>,
+	iterable2: Iterable<IdItem<TValue>>,
+) {
+	const map = new Map<unknown, IdItem<TValue>>();
+	for (const item of iterable1) {
+		map.set(item.id, item);
+	}
+	for (const item2 of iterable2) {
+		const item = map.get(item2.id);
+		if (item) {
+			item.count++;
+			item.proximity += (item2.proximity - item.proximity) / item.count;
+			yield item;
+		}
+	}
+}
+
+function getTrie<TValue>(current: Trie<TValue>, key: string) {
+	const newTrie = current.sub.get(key)!;
+	if (typeof newTrie === 'string') {
+		return current.sub.get(newTrie) as Trie<TValue>;
+	}
+	return newTrie;
+}
+
+function* yieldSubTries<TValue>(
+	keys: string[],
+	trie: Trie<TValue>,
+	prefixes: Trie<unknown>,
+	callback: typeof getFilterSubTries,
+) {
+	if (keys.length === 1) {
+		const [key] = keys;
+		yield* callback(trie.sub.get(key) as Trie<TValue>, getTrie(prefixes, key));
+	} else if (keys.length > 1) {
+		for (const key of keys) {
+			yield* callback(getTrie(trie, key), prefixes.sub.get(key) as Trie);
+		}
+	} else {
+		yield trie;
+	}
+}
+
+function* getFilterSubTries<TValue>(
+	trie: Trie<TValue>,
+	prefixes: Trie,
+): Iterable<Trie<TValue> | undefined> {
+	const keys = [];
+	for (const k of prefixes.sub.keys()) {
+		const value = trie.sub.get(k);
+		if (!value) {
+			yield undefined;
+			return;
+		}
+		if (typeof value !== 'string') {
+			keys.push(k);
+		}
+	}
+
+	yield* yieldSubTries(keys, trie, prefixes, getFilterSubTries);
+}
+
+function combineIterableList<TValue>(
+	iterables: Iterable<IdItem<TValue>>[],
+	iterable: Iterable<IdItem<TValue>>,
+) {
+	for (let i = 1; i < iterables.length; i++) {
+		iterable = combineIterables(iterable, iterables[i]);
+	}
+	return iterable;
+}
+
+export function iterateTrieValues<TValue>(
+	trie: Trie<TValue>,
+	options?: IteratingOptions<TValue>,
+): Iterable<IteratedTrieValue<TValue>>;
+export function iterateTrieValues<TValue>(
+	trie: Trie<TValue>,
+	prefix?: string,
+): Iterable<IteratedTrieValue<TValue>>;
+export function* iterateTrieValues<TValue>(
+	trie: Trie<TValue>,
+	prefixOrPrefix?: IteratingOptions<TValue> | string,
+): Iterable<IteratedTrieValue<TValue>> {
+	const { prefixes, uniqueness, getId } = validateIterationParameters(
+		prefixOrPrefix,
+		trie,
+	);
+	let tries: Array<Trie<TValue> | undefined> = [trie];
+	if (prefixes) {
+		tries = Array.from(getFilterSubTries(trie, prefixes));
+		if (tries.some((x) => !x)) return;
+	}
+
+	const iterables = tries.map((current) =>
+		runIteration(current!, uniqueness, getId),
+	);
+	for (const { proximity, value } of combineIterableList(
+		iterables,
+		iterables[0],
+	)) {
+		yield { proximity, value };
+	}
+}

--- a/src/iterate-trie-values.ts
+++ b/src/iterate-trie-values.ts
@@ -1,25 +1,6 @@
+import { Queue, ShouldYield, IdItem, getQueue } from './utils';
 import { addWord, createEmptyTrie, createTrie } from './trie';
 import { IteratedTrieValue, IteratingOptions, Trie } from './types';
-
-type IdItem<TValue> = IteratedTrieValue<TValue> & {
-	id: unknown;
-	count: number;
-};
-type QueueNode<T> =
-	| {
-			value: T;
-			next?: QueueNode<T>;
-	  }
-	| undefined;
-type Queue<T> = {
-	push(item: T): void;
-	shift(): T | undefined;
-	hasItems(): unknown;
-};
-type ShouldYield = (v: unknown) => {
-	yields: boolean;
-	id: unknown;
-};
 
 const YIELDS_TRUE = { yields: true, id: undefined };
 const ALWAYS_YIELDS = () => YIELDS_TRUE;
@@ -93,34 +74,6 @@ function validateIterationParameters<TValue>(
 	}
 
 	return { prefixes, uniqueness: false, getId: identity };
-}
-
-function getQueue<T>(): Queue<T> {
-	let first: QueueNode<T> | undefined;
-	let last: QueueNode<T> | undefined;
-	return {
-		hasItems() {
-			return first;
-		},
-		shift() {
-			if (first) {
-				const { value } = first;
-				first = first.next;
-				if (!first) {
-					last = first;
-				}
-				return value;
-			}
-		},
-		push(value: T) {
-			const node = { value };
-			if (!last) {
-				first = last = node;
-			} else {
-				last = last.next = node;
-			}
-		},
-	};
 }
 
 function shouldYieldFactory(

--- a/src/iterate-trie-values.ts
+++ b/src/iterate-trie-values.ts
@@ -43,12 +43,12 @@ function getPrefixTrie(
 }
 
 function treatOptions<TValue>(
-	prefixOrPrefix: IteratingOptions<TValue>,
+	options: IteratingOptions<TValue>,
 	trie: Trie<TValue>,
 ) {
-	const [prefixes, count] = getPrefixTrie(prefixOrPrefix.prefixes, trie);
-	let uniqueness = prefixOrPrefix.uniqueness;
-	const getId = prefixOrPrefix.getId;
+	const [prefixes, count] = getPrefixTrie(options.prefixes, trie);
+	let uniqueness = options.uniqueness;
+	const getId = options.getId;
 
 	if (prefixes) {
 		const manyPrefixes = count > 1;
@@ -64,15 +64,15 @@ function treatOptions<TValue>(
 }
 
 function validateIterationParameters<TValue>(
-	prefixOrPrefix: string | IteratingOptions<TValue> | undefined,
+	prefixOrOptions: string | IteratingOptions<TValue> | undefined,
 	trie: Trie<TValue>,
 ) {
 	let prefixes: Trie | undefined;
-	if (prefixOrPrefix) {
-		if (typeof prefixOrPrefix === 'object') {
-			return treatOptions(prefixOrPrefix, trie);
+	if (prefixOrOptions) {
+		if (typeof prefixOrOptions === 'object') {
+			return treatOptions(prefixOrOptions, trie);
 		}
-		prefixes = createTrie([prefixOrPrefix], trie.s);
+		prefixes = createTrie([prefixOrOptions], trie.s);
 	}
 
 	return { prefixes, uniqueness: false, getId: identity };
@@ -215,10 +215,10 @@ export function iterateTrieValues<TValue>(
 ): Iterable<IteratedTrieValue<TValue>>;
 export function* iterateTrieValues<TValue>(
 	trie: Trie<TValue>,
-	prefixOrPrefix?: IteratingOptions<TValue> | string,
+	prefixOrOptions?: IteratingOptions<TValue> | string,
 ): Iterable<IteratedTrieValue<TValue>> {
 	const { prefixes, uniqueness, getId } = validateIterationParameters(
-		prefixOrPrefix,
+		prefixOrOptions,
 		trie,
 	);
 	let tries: Array<Trie<TValue> | undefined> = [trie];

--- a/src/trie-regex.ts
+++ b/src/trie-regex.ts
@@ -21,31 +21,25 @@ function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
 	return exp !== '' ? `(?:${exp}${getEnd(matchType)})` : '';
 }
 
-function validateRegEx(trie: Trie) {
+function getRegEx(trie: Trie<unknown>, matchType: MatchType) {
 	if (trie.$synonymTrie) {
 		throw new TypeError('TrieRegEx does not support tries with synonyms yet');
 	}
+
+	const exp = `^${trieToRegExRecursive(trie, matchType)}`;
+	return new RegExp(exp);
 }
 
 export function trieToRegExPartial(trie: Trie) {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.PARTIAL)}`;
-	return new RegExp(exp);
+	return getRegEx(trie, MatchType.PARTIAL);
 }
 
 export function trieToRegExPerfect(trie: Trie) {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.PERFECT)}`;
-	return new RegExp(exp);
+	return getRegEx(trie, MatchType.PERFECT);
 }
 
 export function trieToRegEx(trie: Trie): TrieRegExp {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.NONE)}`;
-	const regex = new RegExp(exp) as TrieRegExp;
+	const regex = getRegEx(trie, MatchType.NONE) as TrieRegExp;
 
 	regex.match = (text: string) => {
 		const result = regex.exec(`${text}\n`);

--- a/src/trie-regex.ts
+++ b/src/trie-regex.ts
@@ -13,16 +13,17 @@ function getEnd(matchType: MatchType) {
 
 function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
 	let exp = '';
-	for (const [k, v] of trie.sub) {
+	const { c: sub } = trie;
+	for (const k in sub) {
 		exp += exp !== '' ? `|${k}` : k;
-		exp += trieToRegExRecursive(v as Trie, matchType);
+		exp += trieToRegExRecursive(sub[k] as Trie, matchType);
 	}
 
 	return exp !== '' ? `(?:${exp}${getEnd(matchType)})` : '';
 }
 
 function getRegEx(trie: Trie<unknown>, matchType: MatchType) {
-	if (trie.$synonymTrie) {
+	if (trie.s) {
 		throw new TypeError('TrieRegEx does not support tries with synonyms yet');
 	}
 

--- a/src/trie-regex.ts
+++ b/src/trie-regex.ts
@@ -1,0 +1,62 @@
+import { Trie, MatchType, TrieRegExp } from './types';
+
+function getEnd(matchType: MatchType) {
+	switch (matchType) {
+		case MatchType.PERFECT:
+			return '';
+		case MatchType.PARTIAL:
+			return '|$';
+		default:
+			return '|\n';
+	}
+}
+
+function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
+	let exp = '';
+	for (const [k, v] of trie.sub) {
+		exp += exp !== '' ? `|${k}` : k;
+		exp += trieToRegExRecursive(v as Trie, matchType);
+	}
+
+	return exp !== '' ? `(?:${exp}${getEnd(matchType)})` : '';
+}
+
+function validateRegEx(trie: Trie) {
+	if (trie.$synonymTrie) {
+		throw new TypeError('TrieRegEx does not support tries with synonyms yet');
+	}
+}
+
+export function trieToRegExPartial(trie: Trie) {
+	validateRegEx(trie);
+
+	const exp = `^${trieToRegExRecursive(trie, MatchType.PARTIAL)}`;
+	return new RegExp(exp);
+}
+
+export function trieToRegExPerfect(trie: Trie) {
+	validateRegEx(trie);
+
+	const exp = `^${trieToRegExRecursive(trie, MatchType.PERFECT)}`;
+	return new RegExp(exp);
+}
+
+export function trieToRegEx(trie: Trie): TrieRegExp {
+	validateRegEx(trie);
+
+	const exp = `^${trieToRegExRecursive(trie, MatchType.NONE)}`;
+	const regex = new RegExp(exp) as TrieRegExp;
+
+	regex.match = (text: string) => {
+		const result = regex.exec(`${text}\n`);
+		if (!result) {
+			return MatchType.NONE;
+		}
+		const match = result[0];
+		return match[match.length - 1] === '\n'
+			? MatchType.PARTIAL
+			: MatchType.PERFECT;
+	};
+
+	return regex;
+}

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -1,19 +1,4 @@
-import {
-	Letter,
-	Trie,
-	MatchType,
-	TrieRegExp,
-	ProcessedSynonyms,
-	IteratedTrieValue,
-	ReservedWords,
-} from './types';
-
-const RESERVED_WORDS = new Set<string>();
-for (const key in ReservedWords) {
-	if (ReservedWords.hasOwnProperty(key)) {
-		RESERVED_WORDS.add(key);
-	}
-}
+import { Trie, MatchType, ProcessedSynonyms } from './types';
 
 function getLastPerfectMatch(
 	processedSynonyms: ProcessedSynonyms | undefined,
@@ -27,7 +12,7 @@ function getLastPerfectMatch(
 		const { length } = word;
 
 		for (let i = context.i; i < length; i++) {
-			current = current[word[i] as Letter] as Trie;
+			current = current.sub.get(word[i]) as Trie;
 			if (!current) {
 				break;
 			} else if (current.$word) {
@@ -52,7 +37,7 @@ function selfReferenceSynonyms(
 		if (synonyms) {
 			synonyms.forEach((synonym) => {
 				if (synonym !== char) {
-					current[synonym as Letter] = char;
+					current.sub.set(synonym, char);
 				}
 			});
 		}
@@ -68,12 +53,13 @@ export function addWord(trie: Trie, word: string, value?: unknown) {
 		context.char = word[context.i];
 		getLastPerfectMatch(synonymTrie, word, context);
 		const { char } = context;
-		let node = current[char as Letter];
+		const { sub } = current;
+		let node = sub.get(char);
 		if (!node) {
-			node = current[char as Letter] = {};
+			sub.set(char, (node = { sub: new Map() }));
 			selfReferenceSynonyms(synonymTrie, char, current);
 		} else if (typeof node === 'string') {
-			node = current[node as Letter] as Trie;
+			node = sub.get(node) as Trie;
 		}
 		current = node;
 		context.i++;
@@ -90,7 +76,7 @@ export function addWord(trie: Trie, word: string, value?: unknown) {
 export function createEmptyTrie<TValue = never>(
 	synonymTrie?: [Trie, Map<string, string[]>],
 ): Trie<TValue> {
-	return { $synonymTrie: synonymTrie };
+	return { $synonymTrie: synonymTrie, sub: new Map() };
 }
 
 export function createTrie(
@@ -119,23 +105,6 @@ export function createTrieMap<TValue>(
 	return trie;
 }
 
-function pushToStack<TValue>(
-	current: Trie<TValue>,
-	visited: Set<Trie<TValue>>,
-	stack: [Trie<TValue>, number][],
-	proximity: number,
-) {
-	for (const k in current) {
-		if (!RESERVED_WORDS.has(k)) {
-			const value = current[k as Letter]!;
-			if (typeof value !== 'string' && !visited.has(value)) {
-				visited.add(current);
-				stack.push([value, proximity]);
-			}
-		}
-	}
-}
-
 export function getSubTrie<TValue>(word: string, trie: Trie<TValue>) {
 	let current = trie;
 	const { length } = word;
@@ -146,12 +115,12 @@ export function getSubTrie<TValue>(word: string, trie: Trie<TValue>) {
 		context.char = word[context.i];
 		getLastPerfectMatch(synonymTrie, word, context);
 
-		const nextNode = current[context.char as Letter];
+		const nextNode = current.sub.get(context.char);
 		if (!nextNode) return undefined;
 
 		current =
 			typeof nextNode === 'string'
-				? (current[nextNode as Letter] as Trie<TValue>)
+				? (current.sub.get(nextNode) as Trie<TValue>)
 				: nextNode;
 		context.i++;
 	}
@@ -159,44 +128,15 @@ export function getSubTrie<TValue>(word: string, trie: Trie<TValue>) {
 	return current;
 }
 
-export function* iterateTrieValues<TValue>(
-	trie: Trie<TValue>,
-	prefix?: string,
-): Iterable<IteratedTrieValue<TValue>> {
-	if (prefix) {
-		trie = getSubTrie(prefix, trie)!;
-		if (!trie) return;
-	}
-	const visited = new Set([trie]);
-	const stack: [Trie<TValue>, number][] = [[trie, 0]];
-
-	while (stack.length > 0) {
-		const [current, proximity] = stack.pop()!;
-		const word = current.$word;
-		const values = current.$values;
-		if (word && values) {
-			const { length } = values;
-			for (let i = 0; i < length; i++) {
-				const value = values[i];
-				yield { proximity, word, value };
-			}
-		}
-		pushToStack(current, visited, stack, proximity + 1);
-	}
-}
-
 export function processCharSynonyms(
 	synonymChars: string[][],
 ): ProcessedSynonyms {
 	const set = new Set<string>();
-	const trie: Trie = {};
+	const trie = createEmptyTrie();
 	const synonymMap = new Map<string, string[]>();
 
 	for (const synonyms of synonymChars) {
 		for (const synonym of synonyms) {
-			if (RESERVED_WORDS.has(synonym)) {
-				throw new Error(`The word ${synonym} is reserved!`);
-			}
 			if (set.has(synonym)) {
 				throw new Error(`Synonym ${synonym} informed more than once!`);
 			}
@@ -214,64 +154,4 @@ export function matchesTrie<TValue>(word: string, trie: Trie<TValue>) {
 	if (!result) return MatchType.NONE;
 
 	return result.$word ? MatchType.PERFECT : MatchType.PARTIAL;
-}
-
-function trieToRegExRecursive(trie: Trie, matchType: MatchType) {
-	let exp = '';
-	for (const k in trie) {
-		if (!RESERVED_WORDS.has(k)) {
-			exp += exp !== '' ? `|${k}` : k;
-			exp += trieToRegExRecursive(trie[k as Letter] as Trie, matchType);
-		}
-	}
-
-	return exp !== ''
-		? `(?:${exp}${
-				matchType === MatchType.PERFECT
-					? ''
-					: matchType === MatchType.PARTIAL
-					? '|$'
-					: '|\n'
-		  })`
-		: '';
-}
-
-function validateRegEx(trie: Trie) {
-	if (trie.$synonymTrie) {
-		throw new TypeError('TrieRegEx does not support tries with synonyms yet');
-	}
-}
-
-export function trieToRegExPartial(trie: Trie) {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.PARTIAL)}`;
-	return new RegExp(exp);
-}
-
-export function trieToRegExPerfect(trie: Trie) {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.PERFECT)}`;
-	return new RegExp(exp);
-}
-
-export function trieToRegEx(trie: Trie): TrieRegExp {
-	validateRegEx(trie);
-
-	const exp = `^${trieToRegExRecursive(trie, MatchType.NONE)}`;
-	const regex = new RegExp(exp) as TrieRegExp;
-
-	regex.match = (text: string) => {
-		const result = regex.exec(`${text}\n`);
-		if (!result) {
-			return MatchType.NONE;
-		}
-		const match = result[0];
-		return match[match.length - 1] === '\n'
-			? MatchType.PARTIAL
-			: MatchType.PERFECT;
-	};
-
-	return regex;
 }

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -56,7 +56,8 @@ export function addWord(trie: Trie, word: string, value?: unknown) {
 		const { sub } = current;
 		let node = sub.get(char);
 		if (!node) {
-			sub.set(char, (node = { sub: new Map() }));
+			node = { sub: new Map() };
+			sub.set(char, node);
 			selfReferenceSynonyms(synonymTrie, char, current);
 		} else if (typeof node === 'string') {
 			node = sub.get(node) as Trie;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 export type ProcessedSynonyms = [Trie, Map<string, string[]>];
 
 export interface Trie<TValue = unknown> {
-	sub: Map<string, Trie<TValue> | string>;
-	$word?: string;
-	$synonymTrie?: ProcessedSynonyms;
-	$values?: TValue[];
+	c: Record<string, Trie<TValue> | string | undefined>;
+	w?: 1;
+	s?: ProcessedSynonyms;
+	v?: TValue[];
 }
 
 export interface IteratingOptions<TValue> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,50 +1,20 @@
-export type Letter =
-	| 'a'
-	| 'b'
-	| 'c'
-	| 'd'
-	| 'e'
-	| 'f'
-	| 'g'
-	| 'h'
-	| 'i'
-	| 'j'
-	| 'k'
-	| 'l'
-	| 'm'
-	| 'n'
-	| 'o'
-	| 'p'
-	| 'q'
-	| 'r'
-	| 's'
-	| 't'
-	| 'u'
-	| 'v'
-	| 'w'
-	| 'x'
-	| 'y'
-	| 'z';
-
-export enum ReservedWords {
-	$word = '$word',
-	$synonymTrie = '$synonymTrie',
-	$values = '$values',
-}
-
 export type ProcessedSynonyms = [Trie, Map<string, string[]>];
 
-export type Trie<TValue = unknown> = {
-	[k in Letter]?: Trie<TValue> | string;
-} & {
-	[ReservedWords.$word]?: string;
-	[ReservedWords.$synonymTrie]?: ProcessedSynonyms;
-	[ReservedWords.$values]?: TValue[];
-};
+export interface Trie<TValue = unknown> {
+	sub: Map<string, Trie<TValue> | string>;
+	$word?: string;
+	$synonymTrie?: ProcessedSynonyms;
+	$values?: TValue[];
+}
+
+export interface IteratingOptions<TValue> {
+	prefixes?: string | Iterable<string>;
+	uniqueness?: boolean;
+	getId?: (a: TValue) => unknown;
+}
 
 export interface IteratedTrieValue<TValue> {
 	proximity: number;
-	word: string;
 	value: TValue;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,52 @@
+import { IteratedTrieValue } from './types';
+
+export type IdItem<TValue> = IteratedTrieValue<TValue> & {
+	id: unknown;
+	count: number;
+};
+
+export type QueueNode<T> =
+	| {
+			value: T;
+			next?: QueueNode<T>;
+	  }
+	| undefined;
+
+export type Queue<T> = {
+	push(item: T): void;
+	shift(): T | undefined;
+	hasItems(): unknown;
+};
+
+export type ShouldYield = (v: unknown) => {
+	yields: boolean;
+	id: unknown;
+};
+
+export function getQueue<T>(): Queue<T> {
+	let first: QueueNode<T> | undefined;
+	let last: QueueNode<T> | undefined;
+	return {
+		hasItems() {
+			return first;
+		},
+		shift() {
+			if (first) {
+				const { value } = first;
+				first = first.next;
+				if (!first) {
+					last = first;
+				}
+				return value;
+			}
+		},
+		push(value: T) {
+			const node = { value };
+			if (!last) {
+				first = last = node;
+			} else {
+				last = last.next = node;
+			}
+		},
+	};
+}

--- a/test/unit/iterate-trie-values.spec.ts
+++ b/test/unit/iterate-trie-values.spec.ts
@@ -1,0 +1,220 @@
+import {
+	createTrie,
+	createTrieMap,
+	iterateTrieValues,
+	processCharSynonyms,
+} from '../../src';
+
+describe(iterateTrieValues.name, () => {
+	it('should return an empty iterable when Trie has no values', () => {
+		const trie = createTrie(['testing', 'taste', 'thirsty']);
+
+		const result = Array.from(iterateTrieValues(trie));
+
+		expect(result).toEqual([]);
+	});
+
+	it('should return an iterable for the sub-values of the trie', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+			['thirsty', 3],
+			['tester', 4],
+			['test', 5],
+		]);
+
+		const result = Array.from(
+			iterateTrieValues(trie, {
+				prefixes: 'tes',
+			}),
+		).sort((a, b) => a.value - b.value);
+
+		expect(result).toEqual([
+			{ proximity: 4, value: 1 },
+			{ proximity: 3, value: 4 },
+			{ proximity: 1, value: 5 },
+		]);
+	});
+
+	it('should return an iterable with sub-values of the trie when options is informed with prefixes and a synonym list is informed', () => {
+		const trie = createTrieMap(
+			[
+				['testing', 1],
+				['thirsty', 1],
+				['tester', 4],
+				['test', 5],
+				['taste', 2],
+			],
+			processCharSynonyms([['t', 'te']]),
+		);
+
+		const result = Array.from(
+			iterateTrieValues(trie, {
+				prefixes: ['th', 'tes'],
+			}),
+		);
+
+		expect(result).toEqual([{ proximity: 4.5, value: 1 }]);
+	});
+
+	it('should return an iterable with all values of the trie when options is informed without prefixes', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+			['thirsty', 3],
+			['tester', 4],
+			['test', 5],
+		]);
+
+		const result = Array.from(iterateTrieValues(trie, {}));
+
+		expect(result).toEqual([
+			{ proximity: 4, value: 5 },
+			{ proximity: 5, value: 2 },
+			{ proximity: 6, value: 4 },
+			{ proximity: 7, value: 1 },
+			{ proximity: 7, value: 3 },
+		]);
+	});
+
+	it('should return an iterable for the sub-values of the trie with repetitions even when there is multiple values for the same key', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+			['thirsty', 3],
+			['tester', 4],
+			['test', 5],
+			['taste', 6],
+			['thirsty', 7],
+			['testing', 8],
+		]);
+
+		const result = Array.from(iterateTrieValues(trie, 'tes')).sort(
+			(a, b) => a.value - b.value,
+		);
+
+		expect(result).toEqual([
+			{
+				proximity: 4,
+				value: 1,
+			},
+			{ proximity: 3, value: 4 },
+			{ proximity: 1, value: 5 },
+			{ proximity: 4, value: 8 },
+		]);
+	});
+
+	it('should return an empty iterable when prefix fails to find any node', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+		]);
+
+		const result = Array.from(iterateTrieValues(trie, 'tesla')).sort(
+			(a, b) => a.value - b.value,
+		);
+
+		expect(result).toEqual([]);
+	});
+
+	it('should return an iterable for the sub-values of the trie with no repeated values when uniqueness is true', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+			['thirsty', 3],
+			['tester', 4],
+			['test', 5],
+			['taste', 6],
+			['thirsty', 7],
+			['testingzing', 1],
+		]);
+
+		const result = Array.from(
+			iterateTrieValues(trie, {
+				prefixes: 'tes',
+				uniqueness: true,
+			}),
+		).sort((a, b) => a.value - b.value);
+
+		expect(result).toEqual([
+			{
+				proximity: 4,
+				value: 1,
+			},
+			{ proximity: 3, value: 4 },
+			{ proximity: 1, value: 5 },
+		]);
+	});
+
+	it('should return an iterable for the combined sub-values of the trie with no repetitions', () => {
+		const trie = createTrieMap([
+			['testing', 1],
+			['taste', 2],
+			['thirsty', 3],
+			['tester', 4],
+			['test', 5],
+			['tastening', 4],
+			['tastier', 5],
+			['thirsty', 7],
+			['testingzing', 1],
+			['tastingzing', 5],
+		]);
+
+		const result = Array.from(
+			iterateTrieValues(trie, {
+				prefixes: ['tes', 'tas'],
+			}),
+		).sort((a, b) => a.value - b.value);
+
+		expect(result).toEqual([
+			{ proximity: 4.5, value: 4 },
+			{ proximity: 2.5, value: 5 },
+		]);
+	});
+
+	it('should return an iterable for the combined sub-values of the trie with no repetitions using the provided getId criteria', () => {
+		const trie = createTrieMap([
+			['testing', 3],
+			['tas', 6],
+			['thirsty', 9],
+			['tester', 12],
+			['test', 15],
+			['tastening', 12],
+			['tastier', 15],
+			['thirsty', 21],
+			['tes', 3],
+			['tastingzing', 15],
+		]);
+
+		const result = Array.from(
+			iterateTrieValues(trie, {
+				prefixes: ['tes', 'tas'],
+				getId: (a: number) => a % 2,
+			}),
+		).sort((a, b) => a.value - b.value);
+
+		expect(result).toEqual([
+			{ proximity: 2, value: 3 },
+			{ proximity: 1.5, value: 12 },
+		]);
+	});
+
+	it('should throw an error when trying to iterate with uniqueness false and more than one prefix', () => {
+		const trie = createTrieMap([['testing', 3]]);
+		let error: any;
+
+		try {
+			Array.from(
+				iterateTrieValues(trie, {
+					prefixes: ['tes', 'tas'],
+					getId: (a: number) => a % 2,
+					uniqueness: false,
+				}),
+			).sort((a, b) => a.value - b.value);
+		} catch (err) {
+			error = err;
+		}
+
+		expect(error).toBeInstanceOf(TypeError);
+	});
+});

--- a/test/unit/trie.spec.ts
+++ b/test/unit/trie.spec.ts
@@ -1,12 +1,5 @@
 import { MatchType } from './../../src/types';
-import {
-	createTrie,
-	createTrieMap,
-	getSubTrie,
-	iterateTrieValues,
-	matchesTrie,
-	processCharSynonyms,
-} from '../../src';
+import { createTrie, matchesTrie, processCharSynonyms } from '../../src';
 
 describe('trie', () => {
 	describe(matchesTrie.name, () => {
@@ -96,32 +89,82 @@ describe('trie', () => {
 			]);
 
 			expect(result[0]).toEqual({
-				t: {
-					$word: 't',
-					h: {
-						$word: 'th',
-					},
-				},
-				x: {
-					$word: 'x',
-					x: {
-						$word: 'xx',
-					},
-				},
-				j: {
-					$word: 'j',
-					a: {
-						s: {
-							p: {
-								e: {
-									r: {
-										$word: 'jasper',
+				$synonymTrie: undefined,
+				sub: new Map([
+					[
+						't',
+						{
+							$word: 't',
+							sub: new Map([
+								[
+									'h',
+									{
+										$word: 'th',
+										sub: new Map(),
 									},
-								},
-							},
+								],
+							]),
 						},
-					},
-				},
+					],
+					[
+						'x',
+						{
+							$word: 'x',
+							sub: new Map([
+								[
+									'x',
+									{
+										$word: 'xx',
+										sub: new Map(),
+									},
+								],
+							]),
+						},
+					],
+					[
+						'j',
+						{
+							$word: 'j',
+							sub: new Map([
+								[
+									'a',
+									{
+										sub: new Map([
+											[
+												's',
+												{
+													sub: new Map([
+														[
+															'p',
+															{
+																sub: new Map([
+																	[
+																		'e',
+																		{
+																			sub: new Map([
+																				[
+																					'r',
+																					{
+																						$word: 'jasper',
+																						sub: new Map(),
+																					},
+																				],
+																			]),
+																		},
+																	],
+																]),
+															},
+														],
+													]),
+												},
+											],
+										]),
+									},
+								],
+							]),
+						},
+					],
+				]),
 			});
 			expect(result[1]).toEqual(
 				new Map([
@@ -158,107 +201,6 @@ describe('trie', () => {
 
 			expect(error1).toBeInstanceOf(Error);
 			expect(error2).toBeInstanceOf(Error);
-		});
-
-		it('should throw an error when a reserved $word is informed as synonym', () => {
-			let error: any;
-
-			try {
-				processCharSynonyms([
-					['t', 'th'],
-					['$word', 'x'],
-				]);
-			} catch (err) {
-				error = err;
-			}
-
-			expect(error).toBeInstanceOf(Error);
-		});
-
-		it('should throw an error when a reserved $synonymTrie is informed as synonym', () => {
-			let error: any;
-
-			try {
-				processCharSynonyms([
-					['t', 'th'],
-					['$synonymTrie', 'x'],
-				]);
-			} catch (err) {
-				error = err;
-			}
-
-			expect(error).toBeInstanceOf(Error);
-		});
-	});
-
-	describe(iterateTrieValues.name, () => {
-		it('should return an empty iterable when Trie has no values', () => {
-			const trie = createTrie(['testing', 'taste', 'thirsty']);
-
-			const result = Array.from(iterateTrieValues(trie));
-
-			expect(result).toEqual([]);
-		});
-
-		it('should return an iterable for the sub-values of the trie', () => {
-			const trie = createTrieMap([
-				['testing', 1],
-				['taste', 2],
-				['thirsty', 3],
-				['tester', 4],
-				['test', 5],
-			]);
-
-			const result = Array.from(
-				iterateTrieValues(getSubTrie('tes', trie)!),
-			).sort((a, b) => a.value - b.value);
-
-			expect(result).toEqual([
-				{ proximity: 4, word: 'testing', value: 1 },
-				{ proximity: 3, word: 'tester', value: 4 },
-				{ proximity: 1, word: 'test', value: 5 },
-			]);
-		});
-
-		it('should return an iterable for the sub-values of the trie with repetitions even when there is multiple values for the same key', () => {
-			const trie = createTrieMap([
-				['testing', 1],
-				['taste', 2],
-				['thirsty', 3],
-				['tester', 4],
-				['test', 5],
-				['taste', 6],
-				['thirsty', 7],
-				['testing', 8],
-			]);
-
-			const result = Array.from(iterateTrieValues(trie, 'tes')).sort(
-				(a, b) => a.value - b.value,
-			);
-
-			expect(result).toEqual([
-				{
-					word: 'testing',
-					proximity: 4,
-					value: 1,
-				},
-				{ proximity: 3, word: 'tester', value: 4 },
-				{ proximity: 1, word: 'test', value: 5 },
-				{ proximity: 4, word: 'testing', value: 8 },
-			]);
-		});
-
-		it('should return an empty iterable when prefix fails to find any node', () => {
-			const trie = createTrieMap([
-				['testing', 1],
-				['taste', 2],
-			]);
-
-			const result = Array.from(iterateTrieValues(trie, 'tesla')).sort(
-				(a, b) => a.value - b.value,
-			);
-
-			expect(result).toEqual([]);
 		});
 	});
 });

--- a/test/unit/trie.spec.ts
+++ b/test/unit/trie.spec.ts
@@ -89,82 +89,52 @@ describe('trie', () => {
 			]);
 
 			expect(result[0]).toEqual({
-				$synonymTrie: undefined,
-				sub: new Map([
-					[
-						't',
-						{
-							$word: 't',
-							sub: new Map([
-								[
-									'h',
-									{
-										$word: 'th',
-										sub: new Map(),
-									},
-								],
-							]),
+				s: undefined,
+				c: {
+					t: {
+						w: 1,
+						c: {
+							h: {
+								w: 1,
+								c: {},
+							},
 						},
-					],
-					[
-						'x',
-						{
-							$word: 'x',
-							sub: new Map([
-								[
-									'x',
-									{
-										$word: 'xx',
-										sub: new Map(),
-									},
-								],
-							]),
+					},
+					x: {
+						w: 1,
+						c: {
+							x: {
+								w: 1,
+								c: {},
+							},
 						},
-					],
-					[
-						'j',
-						{
-							$word: 'j',
-							sub: new Map([
-								[
-									'a',
-									{
-										sub: new Map([
-											[
-												's',
-												{
-													sub: new Map([
-														[
-															'p',
-															{
-																sub: new Map([
-																	[
-																		'e',
-																		{
-																			sub: new Map([
-																				[
-																					'r',
-																					{
-																						$word: 'jasper',
-																						sub: new Map(),
-																					},
-																				],
-																			]),
-																		},
-																	],
-																]),
+					},
+					j: {
+						w: 1,
+						c: {
+							a: {
+								c: {
+									s: {
+										c: {
+											p: {
+												c: {
+													e: {
+														c: {
+															r: {
+																w: 1,
+																c: {},
 															},
-														],
-													]),
+														},
+													},
 												},
-											],
-										]),
+											},
+										},
 									},
-								],
-							]),
+								},
+							},
 						},
-					],
-				]),
+					},
+				},
 			});
 			expect(result[1]).toEqual(
 				new Map([


### PR DESCRIPTION
### Multiple Prefixes iteration

Now iterateTrieValues supports uniqueness and multiple prefixes to match!

To request uniqueness:
```ts
const trie = createTrieMap([
  ['testing', 1],
  ['taste', 2],
  ['thirsty', 3],
  ['tester', 4],
  ['test', 5],
  ['taste', 6],
  ['thirsty', 7],
  ['testing', 5],
]);

for (const item of iterateTrieValues(trie, {
  prefixes: 'tes',
  uniqueness: true,
)) {
  console.log(item);
}
/*
Result: will print in proximity order
{ proximity: 1, value: 5 },
{ proximity: 3, value: 4 },
{ proximity: 4, value: 1 },
*/
```

You can also inform multiple prefixes and you'll get an iterable with only the values found for all of them.
Notice that this feature implies uniqueness, and if you try to use it with uniqueness false, you'll get an error.
Also, the proximity in the case will be the average proximity for the value with all the prefixes, and you have
no guarantees that the items will be printed in proximity order.

```ts
const trie = createTrieMap([
  ['testing', 1],
  ['taste', 2],
  ['thirsty', 3],
  ['testing', 4],
  ['test', 2],
  ['tas', 4],
  ['thirsty', 7],
  ['testing', 5],
]);

for (const item of iterateTrieValues(trie, {
  prefixes: ['tes', 'tas'],
)) {
  console.log(item);
}

/*
Result: will print in some arbitrary order
{ proximity: 1.5, value: 2 },
{ proximity: 2, value: 4 },
*/
```

### Removing the need for reserved words
Due to how Trie structures were implemented, we had to check for reserved words. The structure is now a bit better to avoid that need. Also, the properties and control values have been changed to a minimum to optimize the transfer of a serialized object, if needed.